### PR TITLE
Verify downloads before installation, put wsl installer into the persistent location, update version to 2.2.1

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -1,6 +1,6 @@
 ﻿// This file is part of BOINC.
 // https://boinc.berkeley.edu
-// Copyright (C) 2025 University of California
+// Copyright (C) 2026 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -81,7 +81,14 @@ namespace boinc_buda_runner_wsl_installer
                 await Task.Delay(10);
                 await window.CheckApplicationUpdateAsync();
 
-                // 2) Windows version
+                // 2) BOINC process must not run
+                var boincOk = await window.CheckBoincProcess();
+                if (!boincOk)
+                {
+                    return ErrBoincRunning;
+                }
+
+                // 3) Windows version
                 window.ChangeRowIconAndStatus(ID.WindowsVersion, "BlueInfoIcon", "Checking Windows version...");
                 await Task.Delay(10);
                 var isSupported = window.CheckWindowsVersionCompatibility();
@@ -91,7 +98,7 @@ namespace boinc_buda_runner_wsl_installer
                     return ErrUnsupportedWindows;
                 }
 
-                // 3) Windows features
+                // 4) Windows features
                 var featuresOk = await window.CheckWindowsFeatures();
                 if (!featuresOk)
                 {
@@ -100,18 +107,11 @@ namespace boinc_buda_runner_wsl_installer
                     return ErrWindowsFeaturesEnableFailed;
                 }
 
-                // 4) WSL check and install/fix
+                // 5) WSL check and install/fix
                 var wslOk = await window.CheckWsl();
                 if (!wslOk)
                 {
                     return ErrWslCheckOrInstallFailed;
-                }
-
-                // 5) BOINC process must not run
-                var boincOk = await window.CheckBoincProcess();
-                if (!boincOk)
-                {
-                    return ErrBoincRunning;
                 }
 
                 // 6) BUDA Runner check/install

--- a/DebugLogger.cs
+++ b/DebugLogger.cs
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // https://boinc.berkeley.edu
-// Copyright (C) 2025 University of California
+// Copyright (C) 2026 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -87,7 +87,7 @@ namespace boinc_buda_runner_wsl_installer
                 LogInfo($"Debug logging started at {DateTime.Now:yyyy-MM-dd HH:mm:ss}", "DebugLogger");
                 LogInfo($"Log file: {_logFilePath}", "DebugLogger");
                 LogInfo($"Application: BOINC WSL Distro Installer", "DebugLogger");
-                LogInfo($"Application Version: 2.2.0", "DebugLogger");
+                LogInfo($"Application Version: 2.2.1", "DebugLogger");
                 LogInfo($"Windows Version: {Environment.OSVersion}", "DebugLogger");
                 LogInfo($"Is 64-bit OS: {Environment.Is64BitOperatingSystem}", "DebugLogger");
                 LogInfo($"Is 64-bit Process: {Environment.Is64BitProcess}", "DebugLogger");

--- a/DownloadVerification.cs
+++ b/DownloadVerification.cs
@@ -1,0 +1,92 @@
+// This file is part of BOINC.
+// https://boinc.berkeley.edu
+// Copyright (C) 2026 University of California
+//
+// BOINC is free software; you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+//
+// BOINC is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
+
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace boinc_buda_runner_wsl_installer
+{
+    internal static class DownloadVerification
+    {
+        public static string ExtractJsonStringValue(string json, string propertyName)
+        {
+            if (string.IsNullOrEmpty(json) || string.IsNullOrEmpty(propertyName)) return null;
+            var pattern = $"\"{Regex.Escape(propertyName)}\"\\s*:\\s*\"((?:\\\\.|[^\"])*)\"";
+            var match = Regex.Match(json, pattern, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+            if (!match.Success) return null;
+
+            var value = match.Groups[1].Value;
+            return UnescapeJsonString(value);
+        }
+
+        public static string TryExtractSha256FromBody(string releaseBody, string fileName)
+        {
+            if (string.IsNullOrEmpty(releaseBody) || string.IsNullOrEmpty(fileName)) return null;
+
+            var patterns = new[]
+            {
+                $@"(?im)^(?<hash>[a-f0-9]{{64}})\s+\*?{Regex.Escape(fileName)}\s*$",
+                $@"(?im)^{Regex.Escape(fileName)}\s*[:=]\s*(?<hash>[a-f0-9]{{64}})\s*$",
+                $@"(?im)^SHA256\s*\(\s*{Regex.Escape(fileName)}\s*\)\s*=\s*(?<hash>[a-f0-9]{{64}})\s*$"
+            };
+
+            foreach (var pattern in patterns)
+            {
+                var match = Regex.Match(releaseBody, pattern, RegexOptions.IgnoreCase | RegexOptions.Multiline);
+                if (match.Success)
+                {
+                    return match.Groups["hash"].Value;
+                }
+            }
+
+            return null;
+        }
+
+        public static string ComputeSha256(string filePath)
+        {
+            using (var stream = File.OpenRead(filePath))
+            using (var sha = SHA256.Create())
+            {
+                var hash = sha.ComputeHash(stream);
+                var sb = new StringBuilder(hash.Length * 2);
+                foreach (var b in hash)
+                {
+                    sb.Append(b.ToString("x2"));
+                }
+                return sb.ToString();
+            }
+        }
+
+        public static string NormalizeHash(string hash)
+        {
+            return string.IsNullOrWhiteSpace(hash) ? null : Regex.Replace(hash.Trim(), @"\s+", string.Empty).ToLowerInvariant();
+        }
+
+        private static string UnescapeJsonString(string value)
+        {
+            if (string.IsNullOrEmpty(value)) return value;
+            return value
+                .Replace("\\r", "\r")
+                .Replace("\\n", "\n")
+                .Replace("\\\"", "\"")
+                .Replace("\\/", "/")
+                .Replace("\\\\", "\\");
+        }
+    }
+}

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -1,7 +1,7 @@
 ﻿<!--
 This file is part of BOINC.
 https://boinc.berkeley.edu
-Copyright (C) 2025 University of California
+Copyright (C) 2026 University of California
 
 BOINC is free software; you can redistribute it and/or modify it
 under the terms of the GNU Lesser General Public License
@@ -23,7 +23,7 @@ along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:boinc_buda_runner_wsl_installer"
         mc:Ignorable="d"
-        Title="BOINC WSL Distro Installer - Version 2.2.0"
+        Title="BOINC WSL Distro Installer - Version 2.2.1"
         Height="450"
         Width="800">
     <Window.Resources>

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -1,6 +1,6 @@
 ﻿// This file is part of BOINC.
 // https://boinc.berkeley.edu
-// Copyright (C) 2025 University of California
+// Copyright (C) 2026 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -65,6 +65,6 @@ using System.Windows;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("2.2.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
+[assembly: AssemblyVersion("2.2.1.0")]
+[assembly: AssemblyFileVersion("2.2.1.0")]
 [assembly: NeutralResourcesLanguage("en-US")]

--- a/app.manifest
+++ b/app.manifest
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="2.2.0.0" name="boinc-buda-runner-wsl-installer.app"/>
+  <assemblyIdentity version="2.2.1.0" name="boinc-buda-runner-wsl-installer.app"/>
 
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
     <security>

--- a/boinc-buda-runner-wsl-installer.csproj
+++ b/boinc-buda-runner-wsl-installer.csproj
@@ -26,7 +26,7 @@
     <UpdateRequired>false</UpdateRequired>
     <MapFileExtensions>true</MapFileExtensions>
     <ApplicationRevision>0</ApplicationRevision>
-    <ApplicationVersion>2.2.0.%2a</ApplicationVersion>
+    <ApplicationVersion>2.2.1.%2a</ApplicationVersion>
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
@@ -81,6 +81,7 @@
     <Compile Include="BoincProcessCheck.cs" />
     <Compile Include="BudaRunnerCheck.cs" />
     <Compile Include="DebugLogger.cs" />
+    <Compile Include="DownloadVerification.cs" />
     <Compile Include="TroubleshootingDialog.xaml.cs">
       <DependentUpon>TroubleshootingDialog.xaml</DependentUpon>
     </Compile>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds SHA256 verification for BUDA Runner and WSL downloads before installing, and stores the verified WSL installer in a persistent hashed folder. Updates the app to version 2.2.1 and moves the BOINC process check earlier in the flow.

- **New Features**
  - Verify BUDA Runner and WSL archives using SHA256 extracted from GitHub release data.
  - Abort and delete the file on hash mismatch; show clear progress messages.
  - Move verified WSL installer to %SystemRoot%\Downloaded Installations/<sha256>/ for persistence.

- **Refactors**
  - Reordered checks: BOINC process is validated before Windows version/features and WSL.
  - Added DownloadVerification helper; GitHub parsing now returns URL + SHA256.
  - Bumped version to 2.2.1 in title, manifest, assembly, and logs.

<sup>Written for commit 9b058d0e828f74cc27f4b80e90e2975314f1451b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

