### PR TITLE
Fix verification of the downloads, increase version to 2.2.2

### DIFF
--- a/BudaRunnerCheck.cs
+++ b/BudaRunnerCheck.cs
@@ -680,8 +680,7 @@ namespace boinc_buda_runner_wsl_installer
         private static BudaRunnerDownloadInfo BuildBudaRunnerDownloadInfo(string releaseJson, string url)
         {
             var fileName = Path.GetFileName(new Uri(url).LocalPath);
-            var body = DownloadVerification.ExtractJsonStringValue(releaseJson, "body");
-            var sha256 = DownloadVerification.TryExtractSha256FromBody(body, fileName);
+            var sha256 = DownloadVerification.TryGetSha256FromReleaseJson(releaseJson, url);
 
             if (string.IsNullOrEmpty(sha256))
             {

--- a/DebugLogger.cs
+++ b/DebugLogger.cs
@@ -87,7 +87,7 @@ namespace boinc_buda_runner_wsl_installer
                 LogInfo($"Debug logging started at {DateTime.Now:yyyy-MM-dd HH:mm:ss}", "DebugLogger");
                 LogInfo($"Log file: {_logFilePath}", "DebugLogger");
                 LogInfo($"Application: BOINC WSL Distro Installer", "DebugLogger");
-                LogInfo($"Application Version: 2.2.1", "DebugLogger");
+                LogInfo($"Application Version: 2.2.2", "DebugLogger");
                 LogInfo($"Windows Version: {Environment.OSVersion}", "DebugLogger");
                 LogInfo($"Is 64-bit OS: {Environment.Is64BitOperatingSystem}", "DebugLogger");
                 LogInfo($"Is 64-bit Process: {Environment.Is64BitProcess}", "DebugLogger");

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -23,7 +23,7 @@ along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:boinc_buda_runner_wsl_installer"
         mc:Ignorable="d"
-        Title="BOINC WSL Distro Installer - Version 2.2.1"
+        Title="BOINC WSL Distro Installer - Version 2.2.2"
         Height="450"
         Width="800">
     <Window.Resources>

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -65,6 +65,6 @@ using System.Windows;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("2.2.1.0")]
-[assembly: AssemblyFileVersion("2.2.1.0")]
+[assembly: AssemblyVersion("2.2.2.0")]
+[assembly: AssemblyFileVersion("2.2.2.0")]
 [assembly: NeutralResourcesLanguage("en-US")]

--- a/WslCheck.cs
+++ b/WslCheck.cs
@@ -954,8 +954,7 @@ namespace boinc_buda_runner_wsl_installer
         private static WslDownloadInfo BuildWslDownloadInfo(string releaseJson, string url)
         {
             var fileName = Path.GetFileName(new Uri(url).LocalPath);
-            var body = DownloadVerification.ExtractJsonStringValue(releaseJson, "body");
-            var sha256 = DownloadVerification.TryExtractSha256FromBody(body, fileName);
+            var sha256 = DownloadVerification.TryGetSha256FromReleaseJson(releaseJson, url);
 
             if (string.IsNullOrEmpty(sha256))
             {

--- a/app.manifest
+++ b/app.manifest
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="2.2.1.0" name="boinc-buda-runner-wsl-installer.app"/>
+  <assemblyIdentity version="2.2.2.0" name="boinc-buda-runner-wsl-installer.app"/>
 
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
     <security>

--- a/boinc-buda-runner-wsl-installer.csproj
+++ b/boinc-buda-runner-wsl-installer.csproj
@@ -26,7 +26,7 @@
     <UpdateRequired>false</UpdateRequired>
     <MapFileExtensions>true</MapFileExtensions>
     <ApplicationRevision>0</ApplicationRevision>
-    <ApplicationVersion>2.2.1.%2a</ApplicationVersion>
+    <ApplicationVersion>2.2.2.%2a</ApplicationVersion>
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes asset download verification by reading the SHA-256 digest tied to each asset’s browser_download_url in the release JSON, preventing mismatched hashes. Bumps app version to 2.2.2.

- **Bug Fixes**
  - Replace body-based hash parsing with TryGetSha256FromReleaseJson; used in BudaRunnerCheck and WslCheck.
  - Match the digest to the exact asset URL and strip the “sha256:” prefix before comparison.

<sup>Written for commit feb1d7a52229597e742bd51fbcff9a814599fae5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

