### PR TITLE
Add uninstallation logic. Set version to 2.3.2

### DIFF
--- a/BudaRunnerCheck.cs
+++ b/BudaRunnerCheck.cs
@@ -67,7 +67,7 @@ namespace boinc_buda_runner_wsl_installer
             public string FileName { get; set; }
         }
 
-        private const string BUDA_RUNNER_IMAGE_NAME = "boinc-buda-runner";
+        public const string BUDA_RUNNER_IMAGE_NAME = "boinc-buda-runner";
         private const string GITHUB_RELEASES_URL = "https://api.github.com/repos/BOINC/boinc-buda-runner-wsl/releases/latest";
 
         /// <summary>
@@ -264,7 +264,7 @@ namespace boinc_buda_runner_wsl_installer
         /// <summary>
         /// Checks if WSL image is installed
         /// </summary>
-        private static async Task<bool> IsWslImageInstalledAsync(string imageName)
+        public static async Task<bool> IsWslImageInstalledAsync(string imageName)
         {
             DebugLogger.LogMethodStart("IsWslImageInstalledAsync", $"imageName: {imageName}", COMPONENT);
 

--- a/BudaRunnerCheck.cs
+++ b/BudaRunnerCheck.cs
@@ -745,7 +745,7 @@ namespace boinc_buda_runner_wsl_installer
         /// <summary>
         /// Removes WSL image
         /// </summary>
-        private static async Task<bool> RemoveWslImageAsync(string imageName)
+        public static async Task<bool> RemoveWslImageAsync(string imageName)
         {
             DebugLogger.LogMethodStart("RemoveWslImageAsync", $"imageName: {imageName}", COMPONENT);
 

--- a/DebugLogger.cs
+++ b/DebugLogger.cs
@@ -87,7 +87,7 @@ namespace boinc_buda_runner_wsl_installer
                 LogInfo($"Debug logging started at {DateTime.Now:yyyy-MM-dd HH:mm:ss}", "DebugLogger");
                 LogInfo($"Log file: {_logFilePath}", "DebugLogger");
                 LogInfo($"Application: BOINC WSL Distro Installer", "DebugLogger");
-                LogInfo($"Application Version: 2.2.2", "DebugLogger");
+                LogInfo($"Application Version: 2.3.2", "DebugLogger");
                 LogInfo($"Windows Version: {Environment.OSVersion}", "DebugLogger");
                 LogInfo($"Is 64-bit OS: {Environment.Is64BitOperatingSystem}", "DebugLogger");
                 LogInfo($"Is 64-bit Process: {Environment.Is64BitProcess}", "DebugLogger");

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -23,7 +23,7 @@ along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:boinc_buda_runner_wsl_installer"
         mc:Ignorable="d"
-        Title="BOINC WSL Distro Installer - Version 2.2.2"
+        Title="BOINC WSL Distro Installer - Version 2.3.2"
         Height="450"
         Width="800">
     <Window.Resources>
@@ -102,9 +102,10 @@ along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
                 <Button Name="OpenLogButton" Content="Open Log" Width="90" Height="30" Margin="5" Click="OpenLogButton_Click"/>
             </StackPanel>
 
-            <!-- Install/Exit on the right -->
+            <!-- Install/Uninstall/Exit on the right -->
             <StackPanel Grid.Column="1" Orientation="Horizontal">
                 <Button Name="InstallButton" Content="Install" Width="80" Height="30" Margin="5" Click="InstallButton_Click"/>
+                <Button Name="UninstallButton" Content="Uninstall" Width="80" Height="30" Margin="5" Click="UninstallButton_Click"/>
                 <Button Name="ExitButton" Content="Exit" Width="80" Height="30" Margin="5" Click="ExitButton_Click"/>
             </StackPanel>
         </Grid>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -843,8 +843,8 @@ namespace boinc_buda_runner_wsl_installer
                 ChangeRowIconAndStatus(ID.BudaRunnerCheck, "BlueInfoIcon", "Checking BOINC WSL Distro installation...");
                 await Task.Delay(100);
 
-                var budaCheckResult = await BudaRunnerCheck.CheckBudaRunnerAsync();
-                if (budaCheckResult.Status == BudaRunnerCheck.BudaRunnerStatus.NotInstalled)
+                bool isInstalled = await BudaRunnerCheck.IsWslImageInstalledAsync(BudaRunnerCheck.BUDA_RUNNER_IMAGE_NAME);
+                if (!isInstalled)
                 {
                     DebugLogger.LogInfo("BOINC WSL Distro is not installed", "MainWindow");
                     ChangeRowIconAndStatus(ID.BudaRunnerCheck, "GreyMinusIcon", "BOINC WSL Distro is not installed");
@@ -864,7 +864,7 @@ namespace boinc_buda_runner_wsl_installer
                 ChangeRowIconAndStatus(ID.BudaRunnerCheck, "BlueInfoIcon", "Removing BOINC WSL Distro...");
                 await Task.Delay(100);
 
-                bool removed = await BudaRunnerCheck.RemoveWslImageAsync("boinc-buda-runner");
+                bool removed = await BudaRunnerCheck.RemoveWslImageAsync(BudaRunnerCheck.BUDA_RUNNER_IMAGE_NAME);
                 if (!removed)
                 {
                     DebugLogger.LogError("Failed to remove BOINC WSL Distro", "MainWindow");

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -835,7 +835,7 @@ namespace boinc_buda_runner_wsl_installer
                 if (confirmResult != MessageBoxResult.Yes)
                 {
                     DebugLogger.LogInfo("User cancelled uninstallation", "MainWindow");
-                    ChangeRowIconAndStatus(ID.BoincProcessCheck, "GreyMinusIcon", "Uninstallation cancelled");
+                    ChangeRowIconAndStatus(ID.BudaRunnerCheck, "GreyMinusIcon", "Uninstallation cancelled");
                     return;
                 }
 

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -34,6 +34,7 @@ namespace boinc_buda_runner_wsl_installer
     {
         public ObservableCollection<TableRow> TableItems { get; set; }
         private bool _isInstalling = false; // track if installation is in progress
+        private bool _isUninstalling = false; // track if uninstallation is in progress
         internal bool LastWindowsFeaturesRestartRequired { get; private set; } // quiet-mode detail
 
         public MainWindow()
@@ -87,15 +88,16 @@ namespace boinc_buda_runner_wsl_installer
         {
             DebugLogger.LogMethodStart("OnClosing", component: "MainWindow");
 
-            if (_isInstalling)
+            if (_isInstalling || _isUninstalling)
             {
+                var operationType = _isInstalling ? "Installation" : "Uninstallation";
                 var result = MessageBox.Show(
-                    "Installation is currently in progress. Are you sure you want to exit?",
+                    $"{operationType} is currently in progress. Are you sure you want to exit?",
                     "Confirm Exit",
                     MessageBoxButton.YesNo,
                     MessageBoxImage.Warning);
 
-                DebugLogger.LogInfo($"Installation in progress exit confirmation dialog result: {result}", "MainWindow");
+                DebugLogger.LogInfo($"{operationType} in progress exit confirmation dialog result: {result}", "MainWindow");
                 if (result != MessageBoxResult.Yes)
                 {
                     e.Cancel = true;
@@ -635,6 +637,13 @@ namespace boinc_buda_runner_wsl_installer
                 DebugLogger.LogInfo("Install button disabled during execution", "MainWindow");
             }
 
+            // Disable Uninstall button during installation
+            if (UninstallButton != null)
+            {
+                UninstallButton.IsEnabled = false;
+                DebugLogger.LogInfo("Uninstall button disabled during installation", "MainWindow");
+            }
+
             bool success = false; // track overall result
             _isInstalling = true; // mark installation started
 
@@ -730,6 +739,14 @@ namespace boinc_buda_runner_wsl_installer
                         DebugLogger.LogInfo("Install succeeded; button remains disabled", "MainWindow");
                     }
                 }
+
+                // Re-enable Uninstall button after installation
+                if (UninstallButton != null)
+                {
+                    UninstallButton.IsEnabled = true;
+                    DebugLogger.LogInfo("Uninstall button re-enabled after installation", "MainWindow");
+                }
+
                 DebugLogger.LogSeparator("Installation Process Completed");
             }
 
@@ -744,6 +761,165 @@ namespace boinc_buda_runner_wsl_installer
             this.Close();
 
             DebugLogger.LogMethodEnd("ExitButton_Click", component: "MainWindow");
+        }
+
+        private async void UninstallButton_Click(object sender, RoutedEventArgs e)
+        {
+            DebugLogger.LogSeparator("Uninstallation Process Started");
+            DebugLogger.LogMethodStart("UninstallButton_Click", component: "MainWindow");
+
+            if (IntroTextBlock != null && IntroTextBlock.Visibility == Visibility.Visible)
+            {
+                IntroTextBlock.Visibility = Visibility.Collapsed;
+            }
+
+            var uninstallButton = sender as Button;
+            if (uninstallButton != null)
+            {
+                uninstallButton.IsEnabled = false;
+                DebugLogger.LogInfo("Uninstall button disabled during execution", "MainWindow");
+            }
+
+            // Disable Install button during uninstallation
+            if (InstallButton != null)
+            {
+                InstallButton.IsEnabled = false;
+                DebugLogger.LogInfo("Install button disabled during uninstallation", "MainWindow");
+            }
+
+            _isUninstalling = true;
+
+            try
+            {
+                // Step 1: Check for running BOINC process
+                ChangeRowIconAndStatus(ID.BoincProcessCheck, "BlueInfoIcon", "Checking BOINC process...");
+                await Task.Delay(100);
+
+                var boincCheckResult = await BoincProcessCheck.CheckBoincProcessAsync();
+                if (boincCheckResult.Status == BoincProcessCheck.BoincProcessStatus.Running)
+                {
+                    DebugLogger.LogWarning("BOINC process is running, cannot proceed with uninstallation", "MainWindow");
+                    ChangeRowIconAndStatus(ID.BoincProcessCheck, "RedCancelIcon", $"{boincCheckResult.Message}");
+
+                    MessageBox.Show(
+                        "BOINC is currently running. Please close BOINC before uninstalling the BOINC WSL Distro.\n\n" +
+                        "To close BOINC:\n" +
+                        "1. Right-click the BOINC icon in the system tray\n" +
+                        "2. Select 'Exit BOINC'\n" +
+                        "3. Run this uninstaller again",
+                        "BOINC is Running",
+                        MessageBoxButton.OK,
+                        MessageBoxImage.Warning);
+                    return;
+                }
+
+                ChangeRowIconAndStatus(ID.BoincProcessCheck, "GreenCheckboxIcon", "BOINC is not running");
+                DebugLogger.LogInfo("BOINC process check passed, not running", "MainWindow");
+
+                // Step 2: Confirm with user
+                var confirmResult = MessageBox.Show(
+                    "Are you sure you want to uninstall BOINC WSL Distro?\n\n" +
+                    "⚠️ WARNING:\n" +
+                    "• This will remove the BOINC WSL Distro from your system\n" +
+                    "• Any Docker-based BOINC tasks will fail after removal\n" +
+                    "• WSL itself will NOT be removed\n\n" +
+                    "To remove WSL completely, please refer to next documentation:\n" +
+                    "https://gist.github.com/4wk-/889b26043f519259ab60386ca13ba91b\n\n" +
+                    "Do you want to continue with uninstallation?",
+                    "Confirm Uninstallation",
+                    MessageBoxButton.YesNo,
+                    MessageBoxImage.Warning);
+
+                DebugLogger.LogInfo($"User confirmation result: {confirmResult}", "MainWindow");
+
+                if (confirmResult != MessageBoxResult.Yes)
+                {
+                    DebugLogger.LogInfo("User cancelled uninstallation", "MainWindow");
+                    ChangeRowIconAndStatus(ID.BoincProcessCheck, "GreyMinusIcon", "Uninstallation cancelled");
+                    return;
+                }
+
+                // Step 3: Check if BOINC WSL Distro is installed
+                ChangeRowIconAndStatus(ID.BudaRunnerCheck, "BlueInfoIcon", "Checking BOINC WSL Distro installation...");
+                await Task.Delay(100);
+
+                var budaCheckResult = await BudaRunnerCheck.CheckBudaRunnerAsync();
+                if (budaCheckResult.Status == BudaRunnerCheck.BudaRunnerStatus.NotInstalled)
+                {
+                    DebugLogger.LogInfo("BOINC WSL Distro is not installed", "MainWindow");
+                    ChangeRowIconAndStatus(ID.BudaRunnerCheck, "GreyMinusIcon", "BOINC WSL Distro is not installed");
+
+                    MessageBox.Show(
+                        "BOINC WSL Distro is not installed on this system.",
+                        "Not Installed",
+                        MessageBoxButton.OK,
+                        MessageBoxImage.Information);
+                    return;
+                }
+
+                ChangeRowIconAndStatus(ID.BudaRunnerCheck, "GreenCheckboxIcon", "BOINC WSL Distro found");
+                DebugLogger.LogInfo("BOINC WSL Distro is installed, proceeding with removal", "MainWindow");
+
+                // Step 4: Remove BOINC WSL Distro
+                ChangeRowIconAndStatus(ID.BudaRunnerCheck, "BlueInfoIcon", "Removing BOINC WSL Distro...");
+                await Task.Delay(100);
+
+                bool removed = await BudaRunnerCheck.RemoveWslImageAsync("boinc-buda-runner");
+                if (!removed)
+                {
+                    DebugLogger.LogError("Failed to remove BOINC WSL Distro", "MainWindow");
+                    ChangeRowIconAndStatus(ID.BudaRunnerCheck, "RedCancelIcon", "Failed to remove BOINC WSL Distro");
+
+                    MessageBox.Show(
+                        "Failed to remove BOINC WSL Distro.\n\nPlease check the log file for details.",
+                        "Uninstallation Failed",
+                        MessageBoxButton.OK,
+                        MessageBoxImage.Error);
+                    return;
+                }
+
+                ChangeRowIconAndStatus(ID.BudaRunnerCheck, "GreenCheckboxIcon", "BOINC WSL Distro removed successfully");
+                DebugLogger.LogInfo("BOINC WSL Distro removed successfully", "MainWindow");
+
+                await Task.Delay(100);
+                MessageBox.Show(
+                    "BOINC WSL Distro has been successfully removed from your system.\n\n" +
+                    "Note: WSL itself remains installed. To remove WSL completely, please refer to:\n" +
+                    "https://gist.github.com/4wk-/889b26043f519259ab60386ca13ba91b",
+                    "Uninstallation Complete",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Information);
+            }
+            catch (Exception ex)
+            {
+                DebugLogger.LogException(ex, "Unexpected error during uninstallation", "MainWindow");
+                MessageBox.Show(
+                    $"An unexpected error occurred during uninstallation:\n\n{ex.Message}\n\nPlease check the log file for details.",
+                    "Uninstallation Error",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error);
+            }
+            finally
+            {
+                _isUninstalling = false;
+
+                if (uninstallButton != null)
+                {
+                    uninstallButton.IsEnabled = true;
+                    DebugLogger.LogInfo("Uninstall button re-enabled", "MainWindow");
+                }
+
+                // Re-enable Install button after uninstallation
+                if (InstallButton != null)
+                {
+                    InstallButton.IsEnabled = true;
+                    DebugLogger.LogInfo("Install button re-enabled after uninstallation", "MainWindow");
+                }
+
+                DebugLogger.LogSeparator("Uninstallation Process Completed");
+            }
+
+            DebugLogger.LogMethodEnd("UninstallButton_Click", component: "MainWindow");
         }
 
         internal void ChangeRowIconAndStatus(ID id, string newIcon, string status)

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -65,6 +65,6 @@ using System.Windows;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("2.2.2.0")]
-[assembly: AssemblyFileVersion("2.2.2.0")]
+[assembly: AssemblyVersion("2.3.2.0")]
+[assembly: AssemblyFileVersion("2.3.2.0")]
 [assembly: NeutralResourcesLanguage("en-US")]

--- a/app.manifest
+++ b/app.manifest
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="2.2.2.0" name="boinc-buda-runner-wsl-installer.app"/>
+  <assemblyIdentity version="2.3.2.0" name="boinc-buda-runner-wsl-installer.app"/>
 
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
     <security>

--- a/boinc-buda-runner-wsl-installer.csproj
+++ b/boinc-buda-runner-wsl-installer.csproj
@@ -26,7 +26,7 @@
     <UpdateRequired>false</UpdateRequired>
     <MapFileExtensions>true</MapFileExtensions>
     <ApplicationRevision>0</ApplicationRevision>
-    <ApplicationVersion>2.2.2.%2a</ApplicationVersion>
+    <ApplicationVersion>2.3.2.%2a</ApplicationVersion>
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a guided Uninstall flow for the BOINC WSL Distro with a dedicated UI button and safeguards. Also fixes version display/metadata to 2.3.2 and avoids GitHub API calls during install checks.

- **New Features**
  - Added Uninstall button to the main window (with a small layout cleanup).
  - Guided uninstallation: ensures BOINC isn’t running; asks for confirmation; checks install via IsWslImageInstalledAsync; removes via RemoveWslImageAsync; updates row status/icons; shows result dialogs; detailed logging.
  - Prevent exit during install/uninstall and disable the opposite action; re-enable after completion.
  - Version updated to 2.3.2 in window title, logs, manifest, and project.

<sup>Written for commit f770247d7b228a6d78fd7288fc56a9a153fe5395. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc-buda-runner-wsl-installer/pull/85?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

