### PR TITLE
Windows Features - Restart messaging changes

### DIFF
--- a/TroubleshootingGuide.cs
+++ b/TroubleshootingGuide.cs
@@ -127,15 +127,16 @@ namespace boinc_buda_runner_wsl_installer
                 Steps = new List<string>
                 {
                     "The installer will automatically enable the required Windows features",
-                    "If a restart is required, you will be prompted",
+                    "A restart might be required, even if you are not prompted to restart",
                     "After restarting, run this installer again to continue",
                     "",
                     "If automatic enablement fails, you can enable features manually:",
                     "1. Open 'Turn Windows features on or off' (search in Start menu)",
                     "2. Enable 'Virtual Machine Platform'",
                     "3. Enable 'Windows Subsystem for Linux'",
-                    "4. Click OK and restart your computer when prompted",
-                    "5. Run this installer again after restart"
+                    "4. Click OK",
+                    "5. Restart your computer",
+                    "6. Run this installer again after restart"
                 },
                 AdditionalResources = new List<string>
                 {
@@ -301,7 +302,7 @@ namespace boinc_buda_runner_wsl_installer
                     "1. Open 'Turn Windows features on or off'",
                     "2. Verify 'Virtual Machine Platform' is checked",
                     "3. Verify 'Windows Subsystem for Linux' is checked",
-                    "4. If not, enable them and restart",
+                    "4. If Windows features were enabled recently, restart your computer",
                     "5. Run this installer again"
                 },
                 AdditionalResources = new List<string>

--- a/TroubleshootingGuide.cs
+++ b/TroubleshootingGuide.cs
@@ -302,8 +302,9 @@ namespace boinc_buda_runner_wsl_installer
                     "1. Open 'Turn Windows features on or off'",
                     "2. Verify 'Virtual Machine Platform' is checked",
                     "3. Verify 'Windows Subsystem for Linux' is checked",
-                    "4. If Windows features were enabled recently, restart your computer",
-                    "5. Run this installer again"
+                    "4. If any were unchecked, check them and click OK",
+                    "5. If any were enabled recently, restart your computer",
+                    "6. Run this installer again"
                 },
                 AdditionalResources = new List<string>
                 {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Clarified Windows restart guidance in the installer troubleshooting for WSL features. Notes a restart may be needed even without a prompt, separates “OK” and “Restart,” adds explicit “click OK” after verifying features, and reminds to restart if features were recently enabled before rerunning the installer.

<sup>Written for commit c4d6603d1760aae270160ee60e8b865a8d537d73. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc-buda-runner-wsl-installer/pull/94?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

